### PR TITLE
corrected test case Storage.count()

### DIFF
--- a/models/user.py
+++ b/models/user.py
@@ -28,5 +28,6 @@ class User(BaseModel, Base):
         """initializes user"""
         from hashlib import md5
         pas = kwargs.get("password", None)
-        kwargs.update({"password": md5(bytes(pas, "utf-8")).hexdigest()})
+        if pas is not None:
+            kwargs.update({"password": md5(bytes(pas, "utf-8")).hexdigest()})
         super().__init__(*args, **kwargs)

--- a/tests/test_models/test_engine/test_db_storage.py
+++ b/tests/test_models/test_engine/test_db_storage.py
@@ -110,6 +110,6 @@ class TestFileStorage(unittest.TestCase):
         storage.reload()
         all_count = storage.count(None)
         self.assertIsInstance(all_count, int)
-        cls_count = storage.count("State")
+        cls_count = storage.count(State)
         self.assertIsInstance(cls_count, int)
         self.assertGreaterEqual(all_count, cls_count)

--- a/tests/test_models/test_engine/test_file_storage.py
+++ b/tests/test_models/test_engine/test_file_storage.py
@@ -137,6 +137,6 @@ class TestFileStorage(unittest.TestCase):
         storage.reload()
         all_count = storage.count()
         self.assertIsInstance(all_count, int)
-        cls_count = storage.count("State")
+        cls_count = storage.count(State)
         self.assertIsInstance(cls_count, int)
         self.assertGreaterEqual(all_count, cls_count)


### PR DESCRIPTION
The count method of storage instance accepts a class type argument not a string.